### PR TITLE
Add build script for Cloudflare Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 public/
 .cache/
 .DS_Store
+zola
+zola-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ zola serve
 Open <http://127.0.0.1:1111> in your browser to preview the site.
 
 ## How to deploy to Cloudflare Pages
-Configure Cloudflare Pages with:
+Cloudflare Pages does not provide Zola out of the box. This repository includes a
+small build script that downloads a compatible binary before generating the
+site. Configure your Pages project with:
 
-- Build command: `zola build`
+- Build command: `bash scripts/build.sh`
 - Output directory: `public`
 
 When linked to the GitHub repository, pushed changes are deployed automatically.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+ZOLA_VERSION="0.19.2"
+ZOLA_ARCHIVE="zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+
+curl -L -o "${ZOLA_ARCHIVE}" "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/${ZOLA_ARCHIVE}"
+tar -xzf "${ZOLA_ARCHIVE}"
+./zola build

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "etak64n-blog"
+pages_build_output_dir = "public"
+
+[build]
+command = "bash scripts/build.sh"


### PR DESCRIPTION
## Summary
- add build script that fetches Zola at build time
- configure Cloudflare Pages via `wrangler.toml`
- document new build command for Pages and ignore build artifacts

## Testing
- `bash scripts/build.sh` *(fails: curl: (56) CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b52f66bf6483238a9aae9275548498