### PR TITLE
Fix Cloudflare Pages build configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/setup-zola@v1
+        with:
+          version: latest
+      - run: zola build
+      - uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: etak64n-blog
+          directory: public

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ zola serve
 
 Open <http://127.0.0.1:1111> in your browser to preview the site.
 
-## How to deploy to Cloudflare Pages
-Cloudflare Pages can install Zola automatically when the `ZOLA_VERSION`
-environment variable is set (see [Deploy a Zola site](https://developers.cloudflare.com/pages/framework-guides/deploy-a-zola-site/)). Configure your Pages project with:
+## Deployment
+The site is built and deployed with GitHub Actions. The workflow runs `zola build`
+and publishes the `public` directory to Cloudflare Pages using the
+[Cloudflare Pages Action](https://github.com/cloudflare/pages-action).
 
-- Environment variable: `ZOLA_VERSION`
-- Build command: `zola build`
-- Output directory: `public`
+To enable deployments, configure the following repository secrets:
 
-When linked to the GitHub repository, pushed changes are deployed automatically.
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+Pushing to the `main` branch triggers the workflow and updates the site.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ zola serve
 Open <http://127.0.0.1:1111> in your browser to preview the site.
 
 ## How to deploy to Cloudflare Pages
-Cloudflare Pages does not provide Zola out of the box. This repository includes a
-small build script that downloads a compatible binary before generating the
-site. Configure your Pages project with:
+Cloudflare Pages can install Zola automatically when the `ZOLA_VERSION`
+environment variable is set. Configure your Pages project with:
 
-- Build command: `bash scripts/build.sh`
+- Environment variable: `ZOLA_VERSION`
+- Build command: `zola build`
 - Output directory: `public`
 
 When linked to the GitHub repository, pushed changes are deployed automatically.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open <http://127.0.0.1:1111> in your browser to preview the site.
 
 ## How to deploy to Cloudflare Pages
 Cloudflare Pages can install Zola automatically when the `ZOLA_VERSION`
-environment variable is set. Configure your Pages project with:
+environment variable is set (see [Deploy a Zola site](https://developers.cloudflare.com/pages/framework-guides/deploy-a-zola-site/)). Configure your Pages project with:
 
 - Environment variable: `ZOLA_VERSION`
 - Build command: `zola build`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-ZOLA_VERSION="0.19.2"
-ZOLA_ARCHIVE="zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-
-curl -L -o "${ZOLA_ARCHIVE}" "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/${ZOLA_ARCHIVE}"
-tar -xzf "${ZOLA_ARCHIVE}"
-./zola build

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,3 @@
 name = "etak64n-blog"
 pages_build_output_dir = "public"
+pages_build_command = "bash scripts/build.sh"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,2 @@
 name = "etak64n-blog"
 pages_build_output_dir = "public"
-pages_build_cmd = "zola build"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,3 @@
 name = "etak64n-blog"
 pages_build_output_dir = "public"
-pages_build_cmd = "bash scripts/build.sh"
+pages_build_cmd = "zola build"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,2 @@
 name = "etak64n-blog"
 pages_build_output_dir = "public"
-
-[build]
-command = "bash scripts/build.sh"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,3 @@
 name = "etak64n-blog"
 pages_build_output_dir = "public"
-pages_build_command = "bash scripts/build.sh"
+pages_build_cmd = "bash scripts/build.sh"


### PR DESCRIPTION
## Summary
- remove unsupported `[build]` section from wrangler.toml used by Cloudflare Pages

## Testing
- `bash scripts/build.sh` *(fails: curl: (56) CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b530934ed0832398b88bb2df1e2e98