### PR TITLE
fix: use install-action for Zola

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/setup-zola@v1
+      - uses: taiki-e/install-action@v2
         with:
-          version: latest
+          tool: zola
       - run: zola build
       - uses: cloudflare/pages-action@v1
         with:


### PR DESCRIPTION
## Summary
- fix GitHub Actions by using `taiki-e/install-action` to install Zola
- remove unsupported `version` field from the install step

## Testing
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/deploy.yml"); puts "YAML OK"'`
- `zola --version` *(fails: command not found)*
- `curl -L https://github.com/getzola/zola/releases/latest/download/zola-x86_64-unknown-linux-gnu.tar.gz -o /tmp/zola.tar.gz` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b540a7f234832389380bf7a93a3a3f