### PR TITLE
ci: skip deploy if secrets missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: zola
-          version: latest
       - run: zola build
       - uses: cloudflare/pages-action@v1
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- skip Cloudflare Pages deployment when secrets are absent
- clean up Zola install step

## Testing
- `zola build` *(fails: command not found)*
- `curl -sSL https://github.com/getzola/zola/releases/latest/download/zola-v0.21.1-x86_64-unknown-linux-gnu.tar.gz -o zola.tar.gz` *(fails: CONNECT tunnel failed: 403)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y zola` *(fails: Unable to locate package zola)*

------
https://chatgpt.com/codex/tasks/task_e_68b5423a4e14832393e65822e2f06e40