### PR TITLE
ci: skip deploy if secrets missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,19 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with:
           tool: zola
-          version: latest
       - run: zola build
       - uses: cloudflare/pages-action@v1
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           projectName: etak64n-blog
           directory: public


### PR DESCRIPTION
## Summary
- guard Cloudflare Pages step by supplying secrets via environment variables and skipping when they're absent

## Testing
- `zola build` *(command not found)*
- `apt-get update` *(403  Forbidden)*
- `apt-get install -y zola` *(Unable to locate package zola)*
- `curl -sSL https://github.com/getzola/zola/releases/latest/download/zola-v0.21.1-x86_64-unknown-linux-gnu.tar.gz -o zola.tar.gz` *(CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5423a4e14832393e65822e2f06e40